### PR TITLE
Expand home section with additional locators and UI tests

### DIFF
--- a/pages/HomePage.ts
+++ b/pages/HomePage.ts
@@ -5,6 +5,7 @@ export class HomePage {
   readonly welcomeHeading: Locator;
   readonly examplesHeading: Locator;
   readonly forkMeOnGithubImage: Locator;
+  readonly footer: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -17,6 +18,7 @@ export class HomePage {
     this.forkMeOnGithubImage = page.getByRole('img', {
       name: 'Fork me on GitHub',
     });
+    this.footer = page.locator('#page-footer');
   }
 
   async goto() {

--- a/pages/HomePage.ts
+++ b/pages/HomePage.ts
@@ -3,11 +3,15 @@ import { Locator, Page } from '@playwright/test';
 export class HomePage {
   readonly page: Page;
   readonly welcomeHeading: Locator;
+  readonly examplesHeading: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.welcomeHeading = page.getByRole('heading', {
       name: 'Welcome to the-internet',
+    });
+    this.examplesHeading = page.getByRole('heading', {
+      name: 'Available Examples',
     });
   }
 

--- a/pages/HomePage.ts
+++ b/pages/HomePage.ts
@@ -2,11 +2,11 @@ import { Locator, Page } from '@playwright/test';
 
 export class HomePage {
   readonly page: Page;
-  readonly heading: Locator;
+  readonly welcomeHeading: Locator;
 
   constructor(page: Page) {
     this.page = page;
-    this.heading = page.getByRole('heading', {
+    this.welcomeHeading = page.getByRole('heading', {
       name: 'Welcome to the-internet',
     });
   }

--- a/pages/HomePage.ts
+++ b/pages/HomePage.ts
@@ -4,6 +4,7 @@ export class HomePage {
   readonly page: Page;
   readonly welcomeHeading: Locator;
   readonly examplesHeading: Locator;
+  readonly forkMeOnGithubImage: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -12,6 +13,9 @@ export class HomePage {
     });
     this.examplesHeading = page.getByRole('heading', {
       name: 'Available Examples',
+    });
+    this.forkMeOnGithubImage = page.getByRole('img', {
+      name: 'Fork me on GitHub',
     });
   }
 

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -4,5 +4,5 @@ import { HomePage } from '../pages/HomePage';
 test('Homepage should display the welcome heading', async ({ page }) => {
   const homePage = new HomePage(page);
   await homePage.goto();
-  await expect(homePage.heading).toBeVisible();
+  await expect(homePage.welcomeHeading).toBeVisible();
 });

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -6,3 +6,11 @@ test('Homepage should display the welcome heading', async ({ page }) => {
   await homePage.goto();
   await expect(homePage.welcomeHeading).toBeVisible();
 });
+
+test('Homepage should display the Available Examples heading', async ({
+  page,
+}) => {
+  const homePage = new HomePage(page);
+  await homePage.goto();
+  await expect(homePage.examplesHeading).toBeVisible();
+});

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -16,4 +16,8 @@ test.describe('Homepage', () => {
   test('should display the Available Examples heading', async () => {
     await expect(homePage.examplesHeading).toBeVisible();
   });
+
+  test('Homepage should display the Fork me on GitHub image', async () => {
+    await expect(homePage.forkMeOnGithubImage).toBeVisible();
+  });
 });

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -20,4 +20,10 @@ test.describe('Homepage', () => {
   test('Homepage should display the Fork me on GitHub image', async () => {
     await expect(homePage.forkMeOnGithubImage).toBeVisible();
   });
+
+  test('Homepage footer should display "Powered by Elemental Selenium" text', async () => {
+    await expect(homePage.footer).toContainText(
+      'Powered by Elemental Selenium',
+    );
+  });
 });

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,16 +1,19 @@
 import { expect, test } from '@playwright/test';
 import { HomePage } from '../pages/HomePage';
 
-test('Homepage should display the welcome heading', async ({ page }) => {
-  const homePage = new HomePage(page);
-  await homePage.goto();
-  await expect(homePage.welcomeHeading).toBeVisible();
-});
+test.describe('Homepage', () => {
+  let homePage: HomePage;
 
-test('Homepage should display the Available Examples heading', async ({
-  page,
-}) => {
-  const homePage = new HomePage(page);
-  await homePage.goto();
-  await expect(homePage.examplesHeading).toBeVisible();
+  test.beforeEach(async ({ page }) => {
+    homePage = new HomePage(page);
+    await homePage.goto();
+  });
+
+  test('should display the welcome heading', async () => {
+    await expect(homePage.welcomeHeading).toBeVisible();
+  });
+
+  test('should display the Available Examples heading', async () => {
+    await expect(homePage.examplesHeading).toBeVisible();
+  });
 });


### PR DESCRIPTION
# Overview  
The goal of this PR is to expand the test coverage of the homepage by adding new locators to the `HomePage` page object and creating additional UI tests. This follows Playwright best practices using the Page Object Model (POM) approach.

## Changes Made:
### Added new locators in `HomePage.ts`:
- `examplesHeading`
- `forkMeOnGithubImage`
- `footer`

### Refactored tests:
- Wrapped tests in a `describe` block
- Moved shared setup into `beforeEach()` to remove duplication
- Renamed the original heading locator to `welcomeHeading` for clarity

### Added new tests in `home.spec.ts`:
- Check that the **"Available Examples"** heading is visible
- Verify the **"Fork me on GitHub"** image is visible
- Ensure the footer contains the text **"Powered by Elemental Selenium"**