### PR TITLE
Add E2E tests for Add/Remove Elements section

### DIFF
--- a/pages/AddRemoveElementsPage.ts
+++ b/pages/AddRemoveElementsPage.ts
@@ -1,0 +1,11 @@
+import { Locator, Page } from '@playwright/test';
+
+export class AddRemoveElementsPage {
+  readonly page: Page;
+  readonly heading: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.heading = page.getByRole('heading', { name: 'Add/Remove Elements' });
+  }
+}

--- a/pages/AddRemoveElementsPage.ts
+++ b/pages/AddRemoveElementsPage.ts
@@ -3,9 +3,11 @@ import { Locator, Page } from '@playwright/test';
 export class AddRemoveElementsPage {
   readonly page: Page;
   readonly heading: Locator;
+  readonly addElementButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.heading = page.getByRole('heading', { name: 'Add/Remove Elements' });
+    this.addElementButton = page.getByRole('button', { name: 'Add Element' });
   }
 }

--- a/pages/AddRemoveElementsPage.ts
+++ b/pages/AddRemoveElementsPage.ts
@@ -4,10 +4,12 @@ export class AddRemoveElementsPage {
   readonly page: Page;
   readonly heading: Locator;
   readonly addElementButton: Locator;
+  readonly deleteButtons: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.heading = page.getByRole('heading', { name: 'Add/Remove Elements' });
     this.addElementButton = page.getByRole('button', { name: 'Add Element' });
+    this.deleteButtons = page.getByRole('button', { name: 'Delete' });
   }
 }

--- a/pages/AddRemoveElementsPage.ts
+++ b/pages/AddRemoveElementsPage.ts
@@ -12,4 +12,10 @@ export class AddRemoveElementsPage {
     this.addElementButton = page.getByRole('button', { name: 'Add Element' });
     this.deleteButtons = page.getByRole('button', { name: 'Delete' });
   }
+
+  async clickAddElementTimes(count: number): Promise<void> {
+    for (let i = 0; i < count; i++) {
+      await this.addElementButton.click();
+    }
+  }
 }

--- a/pages/HomePage.ts
+++ b/pages/HomePage.ts
@@ -6,6 +6,7 @@ export class HomePage {
   readonly examplesHeading: Locator;
   readonly forkMeOnGithubImage: Locator;
   readonly footer: Locator;
+  readonly addRemoveElementsLink: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -19,6 +20,9 @@ export class HomePage {
       name: 'Fork me on GitHub',
     });
     this.footer = page.locator('#page-footer');
+    this.addRemoveElementsLink = page.getByRole('link', {
+      name: 'Add/Remove Elements',
+    });
   }
 
   async goto() {

--- a/tests/add-remove-elements.spec.ts
+++ b/tests/add-remove-elements.spec.ts
@@ -25,6 +25,11 @@ test.describe('Add/Remove Elements page', () => {
   });
 
   test.describe('Interaction', () => {
+    test('should add multiple Delete buttons', async () => {
+      await addRemoveElementsPage.clickAddElementTimes(5);
+      await expect(addRemoveElementsPage.deleteButtons).toHaveCount(5);
+    });
+
     test('should add and then delete a Delete button', async () => {
       await addRemoveElementsPage.clickAddElementTimes(1);
       await expect(addRemoveElementsPage.deleteButtons).toHaveCount(1);

--- a/tests/add-remove-elements.spec.ts
+++ b/tests/add-remove-elements.spec.ts
@@ -27,5 +27,13 @@ test.describe('Add/Remove Elements page', () => {
       await expect(addRemoveElementsPage.deleteButtons).toHaveCount(0);
     });
   });
-  test.describe('Interaction', () => {});
+  test.describe('Interaction', () => {
+    test('should add a single Delete button after clicking "Add Element"', async ({
+      page,
+    }) => {
+      const addRemoveElementsPage = new AddRemoveElementsPage(page);
+      await addRemoveElementsPage.addElementButton.click();
+      await expect(addRemoveElementsPage.deleteButtons).toHaveCount(1);
+    });
+  });
 });

--- a/tests/add-remove-elements.spec.ts
+++ b/tests/add-remove-elements.spec.ts
@@ -27,4 +27,5 @@ test.describe('Add/Remove Elements page', () => {
       await expect(addRemoveElementsPage.deleteButtons).toHaveCount(0);
     });
   });
+  test.describe('Interaction', () => {});
 });

--- a/tests/add-remove-elements.spec.ts
+++ b/tests/add-remove-elements.spec.ts
@@ -10,4 +10,12 @@ test.describe('Add/Remove Elements page', () => {
     const addRemovePage = new AddRemoveElementsPage(page);
     await expect(addRemovePage.heading).toBeVisible();
   });
+
+  test('should display the "Add Element" button by default', async ({
+    page,
+  }) => {
+    const addRemovePage = new AddRemoveElementsPage(page);
+    await expect(addRemovePage.addElementButton).toBeVisible();
+    await expect(addRemovePage.addElementButton).toBeEnabled();
+  });
 });

--- a/tests/add-remove-elements.spec.ts
+++ b/tests/add-remove-elements.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+import { AddRemoveElementsPage } from '../pages/AddRemoveElementsPage';
+
+test.describe('Add/Remove Elements page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/add_remove_elements/');
+  });
+
+  test('should display the Add/Remove Elements heading', async ({ page }) => {
+    const addRemovePage = new AddRemoveElementsPage(page);
+    await expect(addRemovePage.heading).toBeVisible();
+  });
+});

--- a/tests/add-remove-elements.spec.ts
+++ b/tests/add-remove-elements.spec.ts
@@ -25,9 +25,12 @@ test.describe('Add/Remove Elements page', () => {
   });
 
   test.describe('Interaction', () => {
-    test('should add a single Delete button after clicking "Add Element"', async () => {
+    test('should add and then delete a Delete button', async () => {
       await addRemoveElementsPage.addElementButton.click();
       await expect(addRemoveElementsPage.deleteButtons).toHaveCount(1);
+
+      await addRemoveElementsPage.deleteButtons.first().click();
+      await expect(addRemoveElementsPage.deleteButtons).toHaveCount(0);
     });
   });
 });

--- a/tests/add-remove-elements.spec.ts
+++ b/tests/add-remove-elements.spec.ts
@@ -26,7 +26,7 @@ test.describe('Add/Remove Elements page', () => {
 
   test.describe('Interaction', () => {
     test('should add and then delete a Delete button', async () => {
-      await addRemoveElementsPage.addElementButton.click();
+      await addRemoveElementsPage.clickAddElementTimes(1);
       await expect(addRemoveElementsPage.deleteButtons).toHaveCount(1);
 
       await addRemoveElementsPage.deleteButtons.first().click();

--- a/tests/add-remove-elements.spec.ts
+++ b/tests/add-remove-elements.spec.ts
@@ -6,21 +6,25 @@ test.describe('Add/Remove Elements page', () => {
     await page.goto('/add_remove_elements/');
   });
 
-  test('should display the Add/Remove Elements heading', async ({ page }) => {
-    const addRemovePage = new AddRemoveElementsPage(page);
-    await expect(addRemovePage.heading).toBeVisible();
-  });
+  test.describe('Initial State', () => {
+    test('should display the Add/Remove Elements heading', async ({ page }) => {
+      const addRemovePage = new AddRemoveElementsPage(page);
+      await expect(addRemovePage.heading).toBeVisible();
+    });
 
-  test('should display the "Add Element" button by default', async ({
-    page,
-  }) => {
-    const addRemovePage = new AddRemoveElementsPage(page);
-    await expect(addRemovePage.addElementButton).toBeVisible();
-    await expect(addRemovePage.addElementButton).toBeEnabled();
-  });
+    test('should display the "Add Element" button by default', async ({
+      page,
+    }) => {
+      const addRemovePage = new AddRemoveElementsPage(page);
+      await expect(addRemovePage.addElementButton).toBeVisible();
+      await expect(addRemovePage.addElementButton).toBeEnabled();
+    });
 
-  test('should not display any Delete buttons by default', async ({ page }) => {
-    const addRemoveElementsPage = new AddRemoveElementsPage(page);
-    await expect(addRemoveElementsPage.deleteButtons).toHaveCount(0);
+    test('should not display any Delete buttons by default', async ({
+      page,
+    }) => {
+      const addRemoveElementsPage = new AddRemoveElementsPage(page);
+      await expect(addRemoveElementsPage.deleteButtons).toHaveCount(0);
+    });
   });
 });

--- a/tests/add-remove-elements.spec.ts
+++ b/tests/add-remove-elements.spec.ts
@@ -18,4 +18,9 @@ test.describe('Add/Remove Elements page', () => {
     await expect(addRemovePage.addElementButton).toBeVisible();
     await expect(addRemovePage.addElementButton).toBeEnabled();
   });
+
+  test('should not display any Delete buttons by default', async ({ page }) => {
+    const addRemoveElementsPage = new AddRemoveElementsPage(page);
+    await expect(addRemoveElementsPage.deleteButtons).toHaveCount(0);
+  });
 });

--- a/tests/add-remove-elements.spec.ts
+++ b/tests/add-remove-elements.spec.ts
@@ -2,36 +2,30 @@ import { expect, test } from '@playwright/test';
 import { AddRemoveElementsPage } from '../pages/AddRemoveElementsPage';
 
 test.describe('Add/Remove Elements page', () => {
+  let addRemoveElementsPage: AddRemoveElementsPage;
+
   test.beforeEach(async ({ page }) => {
     await page.goto('/add_remove_elements/');
+    addRemoveElementsPage = new AddRemoveElementsPage(page);
   });
 
   test.describe('Initial State', () => {
-    test('should display the Add/Remove Elements heading', async ({ page }) => {
-      const addRemovePage = new AddRemoveElementsPage(page);
-      await expect(addRemovePage.heading).toBeVisible();
+    test('should display the Add/Remove Elements heading', async () => {
+      await expect(addRemoveElementsPage.heading).toBeVisible();
     });
 
-    test('should display the "Add Element" button by default', async ({
-      page,
-    }) => {
-      const addRemovePage = new AddRemoveElementsPage(page);
-      await expect(addRemovePage.addElementButton).toBeVisible();
-      await expect(addRemovePage.addElementButton).toBeEnabled();
+    test('should display the "Add Element" button by default', async () => {
+      await expect(addRemoveElementsPage.addElementButton).toBeVisible();
+      await expect(addRemoveElementsPage.addElementButton).toBeEnabled();
     });
 
-    test('should not display any Delete buttons by default', async ({
-      page,
-    }) => {
-      const addRemoveElementsPage = new AddRemoveElementsPage(page);
+    test('should not display any Delete buttons by default', async () => {
       await expect(addRemoveElementsPage.deleteButtons).toHaveCount(0);
     });
   });
+
   test.describe('Interaction', () => {
-    test('should add a single Delete button after clicking "Add Element"', async ({
-      page,
-    }) => {
-      const addRemoveElementsPage = new AddRemoveElementsPage(page);
+    test('should add a single Delete button after clicking "Add Element"', async () => {
       await addRemoveElementsPage.addElementButton.click();
       await expect(addRemoveElementsPage.deleteButtons).toHaveCount(1);
     });

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -26,4 +26,11 @@ test.describe('Homepage', () => {
       'Powered by Elemental Selenium',
     );
   });
+
+  test('should click the Add/Remove Elements link and verify navigation', async ({
+    page,
+  }) => {
+    await homePage.addRemoveElementsLink.click();
+    await expect(page).toHaveURL(/.*add_remove_elements/);
+  });
 });


### PR DESCRIPTION
# Overview  
This PR expands automation by adding end-to-end (E2E) tests for the [Add/Remove Elements section](https://the-internet.herokuapp.com/add_remove_elements/)

## Changes Made:
### Added `pages/AddRemoveElementsPage.ts`
- introduced locators: 
  - heading 
  - addElementButton
  - deleteButtons
- Added reusable `clickAddElementTimes` function

### Added `tests/add-remove-elements.spec.ts`
- created `Add/Remove Elements page` test suite with `beforeEach`
- Added `Initial State` tests: 
  - 'should display the Add/Remove Elements heading`
  - `should display the "Add Element" button by default`
  - `should not display any Delete buttons by default`
- Added `Interaction` tests:
  - `should add multiple Delete buttons`
  - `should add and then delete a Delete button`


### Enhanced `pages/HomePage.ts` & `tests/home.spec.ts`
- Added `addRemoveElementsLink` locator to `HomePage.ts`
- Added `should click the Add/Remove Elements link and verify navigation` test in `home.spec.ts`
